### PR TITLE
fix/ci: update continuous build action

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -34,11 +34,11 @@ jobs:
 
     - name: Release
       if: github.repository == 'Vanilla-OS/vanilla-tools' && github.ref == 'refs/heads/main'
-      uses: "marvinpinto/action-automatic-releases@latest"
+      uses: softprops/action-gh-release@v1
       with:
-        repo_token: "${{ secrets.GITHUB_TOKEN }}"
-        automatic_release_tag: "continuous"
+        token: "${{ secrets.GITHUB_TOKEN }}"
+        tag_name: "continuous"
         prerelease: true
-        title: "Continuous Build"
+        name: "Continuous Build"
         files: |
           vanilla-tools.tar.gz


### PR DESCRIPTION
## Changes

Update the continuous build workflow from the unmaintained `marvinpinto/action-automatic-releases` (using Node 12) to `softprops/action-gh-release@v1` (Node 16) [We use the same in our other repos].